### PR TITLE
Add Coverity scan integration to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: java
 jdk:
   - oraclejdk8
-notifications:
-  slack: ftsrg:ecvIo6H1l9zFO7qSwf3Juz3U
-  on_success: change
-  on_failure: always
+
+addons:
+  coverity_scan:
+    project:
+      name: "baldan42/neo4j-drivers"
+      description: "Wrappers and decorators for the Neo4j Java Driver"
+    notification_email: gustorn@gmail.com
+    build_command_prepend: "./gradlew clean"
+    build_command:   "./gradlew build"
+    branch_pattern: coverity_scan


### PR DESCRIPTION
I set it up so that it only builds from the `coverity_scan` branch. This makes sure that we don't overstep our quotas on Coverity. Link to the project page: [Coverity](https://scan.coverity.com/projects/baldan42-neo4j-drivers). This depends on Travis tracking the current repository (#4) and creating the `coverity_scan` branch. Once that's done I'll submit a second PR that adds the Coverity Scan badge to readme. 